### PR TITLE
light-content spell mistake .

### DIFF
--- a/ios/NavigationHybrid/HBDGardenModule.m
+++ b/ios/NavigationHybrid/HBDGardenModule.m
@@ -34,7 +34,7 @@ RCT_EXPORT_MODULE(GardenHybrid)
 - (NSDictionary *)constantsToExport {
     return @{
              @"DARK_CONTENT": @"dark-content",
-             @"LIGHT_CONTENT": @"lieht-content",
+             @"LIGHT_CONTENT": @"light-content",
              };
 }
 


### PR DESCRIPTION
“light-content” is right.